### PR TITLE
New grammars (Node.js Buffer and URL), new common.dg items

### DIFF
--- a/dharma/grammars/common.dg
+++ b/dharma/grammars/common.dg
@@ -76,15 +76,34 @@ number :=
 	+integer+
 	+decimal_number+
 
+hex :=
+	%range%(0-9)
+	%range%(A-F)
+
+byte :=
+	0x+hex++hex+
+
 character :=
 	%range%(a-z)
 	%range%(A-Z)
+
+asciichar :=
+	%range%(!-~)
 
 text :=
 	%repeat%(+character+)
 
 font :=
 	Arial
+
+encoding :=
+	ascii
+	utf8
+	utf16le
+	ucs2
+	base64
+	binary
+	hex
 
 image_mime_type :=
 	"image/gif"
@@ -156,3 +175,40 @@ object :=
 	undefined
 	null
 	"+text+"
+
+intoverflow :=
+	0
+	1
+	32768
+	65535
+	65536
+	357913942
+	2147483648
+	4294967296
+	8446744073709551616
+	-0
+	-1
+	-32768
+	-65535
+	-65536
+	-357913942
+	-2147483648
+	-4294967296
+	-8446744073709551616
+	0xff
+	0x3fffffff
+	0xffffffff
+	0xfffffffe
+	0x100
+	0x1000
+	0x10000
+	0x100000
+	0x80000000
+
+formatstr :=
+	%repeat%(%s)
+	%repeat%(%x)
+	%repeat%(%d)
+	AAAAA%s
+	AAAAA%x
+	AAAAA%d

--- a/dharma/grammars/nodejsbuffer.dg
+++ b/dharma/grammars/nodejsbuffer.dg
@@ -1,0 +1,298 @@
+%%% Node.js Buffer grammar 
+
+%%% Based on the official API:
+%%% https://nodejs.org/api/buffer.html#buffer_class_buffer
+%%% https://nodejs.org/api/smalloc.html
+
+%%% ############################################
+%section% := value
+
+definition :=
+	+defvar+ +buftype+;
+
+defvar :=
+	var buf = new
+
+buftype :=
+	+bufsize+
+	+bufarray+
+	+bufbuffer+
+	+bufstr+
+
+bufsize :=
+	Buffer(+common:int+)
+	Buffer(+common:short_int+)
+	Buffer(+common:intoverflow+)
+
+bufarray :=
+	Buffer([+arrayvalues+])
+
+arrayvalues :=
+	%repeat%(+common:int+, ", ")
+	%repeat%(+common:short_int+, ", ")
+	%repeat%(+common:intoverflow+, ", ")
+	%repeat%(+common:byte+, ", ")
+
+bufbuffer :=
+	Buffer(new +bufsize+)
+	Buffer(new +bufarray+)
+	Buffer(new +bufbuffer+)
+	Buffer(new +bufstr+)
+
+bufstr :=
+	Buffer("+textcnt+", "+encoding+")
+
+%%% Permutations ############################################
+
+permutation :=
+	buf = Buffer.concat([%repeat%(new +buftype+, ", ")]);
+	buf = Buffer.concat([%repeat%(new +buftype+, ", ")], +common:int+);
+	buf = Buffer.concat([%repeat%(new +buftype+, ", ")], +common:short_int+);
+	buf = Buffer.concat([%repeat%(new +buftype+, ", ")], +common:intoverflow+);
+	buf[+common:int+] = buf[+common:int+];
+	buf[+common:short_int+] = buf[+common:short_int+];
+	buf[+common:intoverflow+] = buf[+common:intoverflow+];
+	(new +bufsize+).copy(buf, +common:int+);
+	(new +bufsize+).copy(buf, +common:int+, +common:int+);
+	(new +bufsize+).copy(buf, +common:int+, +common:int+, +common:int+);
+	(new +bufsize+).copy(buf, +common:short_int+);
+	(new +bufsize+).copy(buf, +common:short_int+, +common:short_int+);
+	(new +bufsize+).copy(buf, +common:short_int+, +common:short_int+, +common:short_int+);
+	(new +bufsize+).copy(buf, +common:intoverflow+);
+	(new +bufsize+).copy(buf, +common:intoverflow+, +common:intoverflow+);
+	(new +bufsize+).copy(buf, +common:intoverflow+, +common:intoverflow+, +common:intoverflow+);
+	(new +bufarray+).copy(buf, +common:int+);
+	(new +bufarray+).copy(buf, +common:int+, +common:int+);
+	(new +bufarray+).copy(buf, +common:int+, +common:int+, +common:int+);
+	(new +bufarray+).copy(buf, +common:short_int+);
+	(new +bufarray+).copy(buf, +common:short_int+, +common:short_int+);
+	(new +bufarray+).copy(buf, +common:short_int+, +common:short_int+, +common:short_int+);
+	(new +bufarray+).copy(buf, +common:intoverflow+);
+	(new +bufarray+).copy(buf, +common:intoverflow+, +common:intoverflow+);
+	(new +bufarray+).copy(buf, +common:intoverflow+, +common:intoverflow+, +common:intoverflow+);
+	(new +bufbuffer+).copy(buf, +common:int+);
+	(new +bufbuffer+).copy(buf, +common:int+, +common:int+);
+	(new +bufbuffer+).copy(buf, +common:int+, +common:int+, +common:int+);
+	(new +bufbuffer+).copy(buf, +common:short_int+);
+	(new +bufbuffer+).copy(buf, +common:short_int+, +common:short_int+);
+	(new +bufbuffer+).copy(buf, +common:short_int+, +common:short_int+, +common:short_int+);
+	(new +bufbuffer+).copy(buf, +common:intoverflow+);
+	(new +bufbuffer+).copy(buf, +common:intoverflow+, +common:intoverflow+);
+	(new +bufbuffer+).copy(buf, +common:intoverflow+, +common:intoverflow+, +common:intoverflow+);
+	(new +bufstr+).copy(buf, +common:int+);
+	(new +bufstr+).copy(buf, +common:int+, +common:int+);
+	(new +bufstr+).copy(buf, +common:int+, +common:int+, +common:int+);
+	(new +bufstr+).copy(buf, +common:short_int+);
+	(new +bufstr+).copy(buf, +common:short_int+, +common:short_int+);
+	(new +bufstr+).copy(buf, +common:short_int+, +common:short_int+, +common:short_int+);
+	(new +bufstr+).copy(buf, +common:intoverflow+);
+	(new +bufstr+).copy(buf, +common:intoverflow+, +common:intoverflow+);
+	(new +bufstr+).copy(buf, +common:intoverflow+, +common:intoverflow+, +common:intoverflow+);
+	buf = buf.slice(0, +common:short_int+);
+	buf = buf.slice(+common:short_int+, +common:short_int+);
+	buf = buf.slice(0, +common:int+);
+	buf = buf.slice(+common:int+, +common:int+);
+	buf = buf.slice(0, +common:intoverflow+);
+	buf.fill("+common:character+"); 
+	buf.fill(+common:byte+); 
+	buf.fill("+common:character+", +common:short_int+); 
+	buf.fill("+common:character+", +common:int+); 
+	buf.fill("+common:character+", +common:intoverflow+); 
+	buf.fill("+common:character+", +common:short_int+, +common:short_int+); 
+	buf.fill("+common:character+", +common:int+, +common:int+); 
+	buf.fill("+common:character+", +common:intoverflow+, +common:intoverflow+); 
+%%%	Smalloc specific
+	smalloc.alloc(+common:int+);
+	smalloc.alloc(+common:short_int+);
+	smalloc.alloc(+common:intoverflow+);
+	smalloc.alloc(+common:int+, buf);
+	smalloc.alloc(+common:short_int+, buf);
+	smalloc.alloc(+common:intoverflow+, buf);
+	smalloc.alloc(+common:int+, buf, "+enumtype+");
+	smalloc.alloc(+common:short_int+, buf, "+enumtype+");
+	smalloc.alloc(+common:intoverflow+, buf, "+enumtype+");
+	smalloc.copyOnto(buf, +common:int+, buf, +common:int+, +common:int+);
+	smalloc.copyOnto(buf, +common:short_int+, buf, +common:short_int+, +common:short_int+);
+	smalloc.copyOnto(buf, +common:digit+, buf, +common:digit+, +common:intoverflow+);
+
+%%% Operations ############################################
+
+operation :=
+	Buffer.isEncoding("+encoding+");
+	Buffer.isBuffer(buf);
+	Buffer.byteLength("+textcnt+", "+encoding+");
+	buf.compare(buf);
+	buf.equals(buf);
+	buf.length;
+	buf.write("+textcnt+", +common:short_int+, +common:short_int+, "+encoding+");
+	buf.write("+textcnt+", +common:int+, +common:int+, "+encoding+");
+	buf.write("+textcnt+", +common:intoverflow+, +common:intoverflow+, "+encoding+");
+	buf.writeUIntLE(+common:short_int+, +common:short_int+, %range%(0-6));
+	buf.writeUIntLE(+common:int+, +common:int+, %range%(0-6));
+	buf.writeUIntLE(+common:intoverflow+, +common:intoverflow+, %range%(0-6));
+	buf.writeUIntBE(+common:short_int+, +common:short_int+, %range%(0-6));
+	buf.writeUIntBE(+common:int+, +common:int+, %range%(0-6));
+	buf.writeUIntBE(+common:intoverflow+, +common:intoverflow+, %range%(0-6));
+	buf.writeIntLE(+common:short_int+, +common:short_int+, %range%(0-6));
+	buf.writeIntLE(+common:int+, +common:int+, %range%(0-6));
+	buf.writeIntLE(+common:intoverflow+, +common:intoverflow+, %range%(0-6));
+	buf.writeIntBE(+common:short_int+, +common:short_int+, %range%(0-6));
+	buf.writeIntBE(+common:int+, +common:int+, %range%(0-6));
+	buf.writeIntBE(+common:intoverflow+, +common:intoverflow+, %range%(0-6));
+	buf.readUIntLE(+common:short_int+, %range%(0-6));
+	buf.readUIntLE(+common:int+, %range%(0-6));
+	buf.readUIntLE(+common:intoverflow+, %range%(0-6));
+	buf.readUIntBE(+common:short_int+, %range%(0-6));
+	buf.readUIntBE(+common:int+, %range%(0-6));
+	buf.readUIntBE(+common:intoverflow+, %range%(0-6));
+	buf.readIntLE(+common:short_int+, %range%(0-6));
+	buf.readIntLE(+common:int+, %range%(0-6));
+	buf.readIntLE(+common:intoverflow+, %range%(0-6));
+	buf.readIntBE(+common:short_int+, %range%(0-6));
+	buf.readIntBE(+common:int+, %range%(0-6));
+	buf.readIntBE(+common:intoverflow+, %range%(0-6));
+	buf.toString("+encoding+", +common:short_int+, +common:short_int+);
+	buf.toString("+encoding+", +common:int+, +common:int+);
+	buf.toString("+encoding+", +common:intoverflow+, +common:intoverflow+);
+	buf.toString("+encoding+");
+	buf.toString("+encoding+", +common:short_int+);
+	buf.toString("+encoding+", +common:int+);
+	buf.toString("+encoding+", +common:intoverflow+);
+	buf.toString();
+	buf.toJSON();
+	buf.readUInt8(+common:short_int+);
+	buf.readUInt8(+common:int+);
+	buf.readUInt8(+common:intoverflow+);
+	buf.readUInt16LE(+common:short_int+);
+	buf.readUInt16LE(+common:int+);
+	buf.readUInt16LE(+common:intoverflow+);
+	buf.readUInt16BE(+common:short_int+);
+	buf.readUInt16BE(+common:int+);
+	buf.readUInt16BE(+common:intoverflow+);
+	buf.readUInt32LE(+common:short_int+);
+	buf.readUInt32LE(+common:int+);
+	buf.readUInt32LE(+common:intoverflow+);
+	buf.readUInt32BE(+common:short_int+);
+	buf.readUInt32BE(+common:int+);
+	buf.readUInt32BE(+common:intoverflow+);
+	buf.readInt8(+common:short_int+);
+	buf.readInt8(+common:int+);
+	buf.readInt8(+common:intoverflow+);
+	buf.readInt16LE(+common:short_int+);
+	buf.readInt16LE(+common:int+);
+	buf.readInt16LE(+common:intoverflow+);
+	buf.readInt16BE(+common:short_int+);
+	buf.readInt16BE(+common:int+);
+	buf.readInt16BE(+common:intoverflow+);
+	buf.readInt32LE(+common:short_int+);
+	buf.readInt32LE(+common:int+);
+	buf.readInt32LE(+common:intoverflow+);
+	buf.readInt32BE(+common:short_int+);
+	buf.readInt32BE(+common:int+);
+	buf.readInt32BE(+common:intoverflow+);
+	buf.readFloatLE(+common:short_int+);
+	buf.readFloatLE(+common:int+);
+	buf.readFloatLE(+common:intoverflow+);
+	buf.readFloatBE(+common:short_int+);
+	buf.readFloatBE(+common:int+);
+	buf.readFloatBE(+common:intoverflow+);
+	buf.readDoubleLE(+common:short_int+);
+	buf.readDoubleLE(+common:int+);	
+	buf.readDoubleLE(+common:intoverflow+);
+	buf.readDoubleBE(+common:short_int+);
+	buf.readDoubleBE(+common:int+);
+	buf.readDoubleBE(+common:intoverflow+);
+	buf.writeUInt8(+common:short_int+, +common:short_int+);
+	buf.writeUInt8(+common:int+, +common:int+);
+	buf.writeUInt8(+common:intoverflow+, +common:short_int+);
+	buf.writeUInt8(+common:short_int+, +common:intoverflow+);
+	buf.writeUInt16LE(+common:short_int+, +common:short_int+);
+	buf.writeUInt16LE(+common:int+, +common:int+);
+	buf.writeUInt16LE(+common:intoverflow+, +common:short_int+);
+	buf.writeUInt16LE(+common:short_int+, +common:intoverflow+);
+	buf.writeUInt16BE(+common:short_int+, +common:short_int+);
+	buf.writeUInt16BE(+common:int+, +common:int+);
+	buf.writeUInt16BE(+common:intoverflow+, +common:short_int+);
+	buf.writeUInt16BE(+common:short_int+, +common:intoverflow+);
+	buf.writeUInt32LE(+common:short_int+, +common:short_int+);
+	buf.writeUInt32LE(+common:int+, +common:int+);
+	buf.writeUInt32LE(+common:intoverflow+, +common:short_int+);
+	buf.writeUInt32LE(+common:short_int+, +common:intoverflow+);
+	buf.writeUInt32BE(+common:short_int+, +common:short_int+);
+	buf.writeUInt32BE(+common:int+, +common:int+);
+	buf.writeUInt32BE(+common:intoverflow+, +common:short_int+);
+	buf.writeUInt32BE(+common:short_int+, +common:intoverflow+);
+	buf.writeInt8(+common:short_int+, +common:short_int+);
+	buf.writeInt8(+common:int+, +common:int+);
+	buf.writeInt8(+common:intoverflow+, +common:short_int+);
+	buf.writeInt8(+common:short_int+, +common:intoverflow+);
+	buf.writeInt16LE(+common:short_int+, +common:short_int+);
+	buf.writeInt16LE(+common:int+, +common:int+);
+	buf.writeInt16LE(+common:intoverflow+, +common:short_int+);
+	buf.writeInt16LE(+common:short_int+, +common:intoverflow+);
+	buf.writeInt16BE(+common:short_int+, +common:short_int+);
+	buf.writeInt16BE(+common:int+, +common:int+);
+	buf.writeInt16BE(+common:intoverflow+, +common:short_int+);
+	buf.writeInt16BE(+common:short_int+, +common:intoverflow+);
+	buf.writeInt32LE(+common:short_int+, +common:short_int+);
+	buf.writeInt32LE(+common:int+, +common:int+);
+	buf.writeInt32LE(+common:intoverflow+, +common:short_int+);
+	buf.writeInt32LE(+common:short_int+, +common:intoverflow+);
+	buf.writeInt32BE(+common:short_int+, +common:short_int+);
+	buf.writeInt32BE(+common:int+, +common:int+);
+	buf.writeInt32BE(+common:intoverflow+, +common:short_int+);
+	buf.writeInt32BE(+common:short_int+, +common:intoverflow+);
+	buf.writeFloatLE(+common:short_int+, +common:short_int+);
+	buf.writeFloatLE(+common:int+, +common:int+);
+	buf.writeFloatLE(+common:intoverflow+, +common:short_int+);
+	buf.writeFloatLE(+common:short_int+, +common:intoverflow+);
+	buf.writeFloatBE(+common:short_int+, +common:short_int+);
+	buf.writeFloatBE(+common:int+, +common:int+);
+	buf.writeFloatBE(+common:intoverflow+, +common:short_int+);
+	buf.writeFloatBE(+common:short_int+, +common:intoverflow+);
+	buf.writeDoubleLE(+common:short_int+, +common:short_int+);
+	buf.writeDoubleLE(+common:int+, +common:int+);
+	buf.writeDoubleLE(+common:intoverflow+, +common:short_int+);
+	buf.writeDoubleLE(+common:short_int+, +common:intoverflow+);
+	buf.writeDoubleBE(+common:short_int+, +common:short_int+);
+	buf.writeDoubleBE(+common:int+, +common:int+);
+	buf.writeDoubleBE(+common:intoverflow+, +common:short_int+);
+	buf.writeDoubleBE(+common:short_int+, +common:intoverflow+);
+
+%%% Utilities ############################################
+
+textcnt :=
+	+common:text+
+	\u00+common:hex++common:hex+
+	\u+common:hex++common:hex++common:hex++common:hex+
+	+common:formatstr+	
+
+encoding :=
+	ascii
+	utf8
+	utf16le
+	ucs2
+	base64
+	binary
+	hex
+
+enumtype :=
+	Int8
+	Uint8
+	Int16
+	Uint16
+	Int32
+	Uint32
+	Float
+	Double
+	Uint8Clamped
+
+%%% ############################################
+%section% := variance
+
+%%% Definition -> Create a Buffer
+%%% Permutation -> Functions from Buffer to Buffer
+%%% Operation -> Functions from Buffer to other types
+
+main := 
+	var smalloc = require('smalloc'); +definition+ +permutation+ +operation+

--- a/dharma/grammars/url.dg
+++ b/dharma/grammars/url.dg
@@ -1,0 +1,326 @@
+%%% Uniform Resource Locator grammar
+
+%%% Based on the official URL BNF:
+%%% http://www.w3.org/Addressing/URL/5_BNF.html
+%%% http://www.w3.org/Protocols/rfc822/#z7
+
+%%% ############################################
+%section% := value
+
+url :=
+	+httpaddress+
+	+ftpaddress+
+	+newsaddress+
+	+nntpaddress+
+	+prosperoaddress+
+	+telnetaddress+
+	+gopheraddress+
+	+waisaddress+
+	+mailtoaddress+
+	+midaddress+
+	+cidaddress+
+
+scheme :=
+	+ialpha+
+
+httpaddress :=
+	http://+hostport+ 
+	http://+hostport+/+path+
+	http://+hostport+/+path+?+search+
+
+ftpaddress :=
+	ftp://+login+/+path+
+	ftp://+login+/+path+;+ftptype+
+
+afsaddress :=
+	afs://+cellname+/+path+
+
+newsaddress :=
+	news:+groupart+
+
+nntpaddress :=
+	nntp:+group+/+digit+
+
+midaddress :=
+	mid:+addrspec+
+
+cidaddress :=
+	cid:+addrspec+
+
+mailtoaddress :=
+	mailto:+xalphas+@+hostname+
+
+waisaddress :=
+	+waisindex+
+	+waisdoc+
+
+waisindex :=
+	wais://+hostport+/+database+
+	wais://+hostport+/+database+?+search+
+
+waisdoc :=
+	wais://+hostport+/+database+/+wtype+/+wpath+
+
+wpath :=
+	+digits+=+path+; 
+	+digits+=+path+;+wpath+
+
+groupart :=
+	*
+	+group+
+	+article+
+
+group :=
+	+ialpha+
+	+ialpha+.+group+
+
+article :=
+	+xalphas+@+host+
+
+database :=
+	+xalphas+
+
+wtype :=
+	+xalphas+
+
+prosperoaddress :=
+	+prosperolink+
+
+prosperolink :=
+	prospero://+hostport+/+hsoname+
+	prospero://+hostport+/+hsoname+%00+version+
+	prospero://+hostport+/+hsoname+%00+version++attributes+
+
+hsoname :=
+	+path+
+
+version :=
+	+digits+
+
+attributes :=
+	+attribute+
+	+attribute++attributes+
+
+attribute :=
+	+alphanums+
+
+telnetaddress :=
+	telnet://+login+
+
+gopheraddress :=
+	gopher://+hostport+
+	gopher://+hostport+/+gtype+
+	gopher://+hostport+/+gtype++gcommand+
+
+login :=
+	+hostport+
+	+user+@+hostport+
+	+user+:+password+@+hostport+
+
+hostport :=
+	+host+
+	+host+:+port+
+
+host :=
+	+hostname+
+	+hostnumber+
+
+ftptype :=
+	A+formcode+
+	E+formcode+
+	I
+	L+digits+
+
+formcode :=
+	N
+	T
+	C
+
+cellname :=
+	+hostname+
+
+hostname :=
+	+ialpha+
+	+ialpha+.+hostname+
+
+hostnumber :=
+	+digits+.+digits+.+digits+.+digits+
+
+port :=
+	+digits+
+
+gcommand :=
+	+path+
+
+path :=
+	+segment+
+	+segment+/+path+
+
+segment :=
+	+xpalphas+
+
+search :=
+	+xalphas+
+	+xalphas+++search+
+
+user :=
+	+alphanum2+
+	+alphanum2++user+
+
+password :=
+	+alphanum2+
+	+alphanum2++password+
+
+fragmentid :=
+	+xalphas+
+	
+gtype :=
+	+xalpha+
+
+alphanum2 :=
+	+alpha+
+	+digit+
+	-
+	_
+	.
+	+
+
+xalpha :=
+	+alpha+
+	+digit+
+	+safe+
+	+extra+
+	+escape+
+
+xalphas :=
+	+xalpha+
+	+xalpha++xalphas+
+
+xpalpha :=
+	+xalpha+
+	+
+
+xpalphas :=
+	+xpalpha+
+	+xpalpha++xpalphas+
+
+ialpha :=
+	+alpha+
+	+alpha++xalphas+
+
+alpha :=
+	+common:character+
+
+digit := 
+	+common:digit+
+
+safe :=
+	$
+	-
+	_
+	@
+	.
+	&
+	+
+	-
+
+extra :=
+	!
+	*
+	"
+	'
+	(
+	)
+	,
+
+reserved :=
+	=
+	;
+	/
+	#
+	?
+	:
+
+escape :=
+	%+common:hex++common:hex+
+
+national :=
+	{
+	}
+	|
+	[
+	]
+	\
+	^
+	~
+
+punctuation :=
+	<
+	>
+
+digits :=
+	+digit+
+	+digit++digits+
+
+alphanum :=
+	+alpha+
+	+digit+
+
+alphanums :=
+	+alphanum+
+	+alphanum++alphanums+
+
+addrspec :=
+	+localpart+@+domain+
+
+localpart :=
+	+words+
+
+domain :=
+	+subdomains+
+	
+subdomains := 
+	+subdomain+
+	+subdomain++subdomains+
+
+subdomain :=
+	+domainref+
+	+domainliteral+
+
+domainref :=
+	+atom+
+
+words :=
+	+word+
+	+word++words+
+
+word :=
+	+atom+
+	+quotedpair+
+
+atom :=
+	%range%(!-')
+	%range%(*-+)
+	%range%(/-9)
+	%range%(A-Z)
+	%range%(^-~)
+	-
+	=
+	?
+
+domainliteral := 
+	[+domaincon+]
+
+domaincon :=
+	+atom+
+	+quotedpair+
+	+domaincon+
+
+quotedpair :=
+	"+common:asciichar+"
+
+%%% ############################################
+%section% := variance
+
+main :=
+	+url+


### PR DESCRIPTION
A few additions for the Dharma grammars:
- New items in common.dg, including test cases for integer overflow and format string bugs
- URL grammar based on http://www.w3.org/Addressing/URL/5_BNF.html
- Grammar to exercise Node.js Buffer and Smalloc. Based on the original APIs, with a few deviations in order to trigger bugs. Using this grammar, I was able to regenerate the recent Node.js/V8 out-of-band write in UTF8 decoder 
