### PR TITLE
Break recursive definition in svg grammar.

### DIFF
--- a/dharma/core/dharma.py
+++ b/dharma/core/dharma.py
@@ -188,10 +188,10 @@ class DharmaVariable(DharmaObject):
         """Return a random variable if any, otherwise create a new default variable."""
         if self.count >= random.randint(DharmaConst.VARIABLE_MIN, DharmaConst.VARIABLE_MAX):
             return "%s%d" % (self.var, random.randint(1, self.count))
-        self.count += 1
         var = random.choice(self)
         prefix = self.eval(var[0], state)
         suffix = self.eval(var[1], state)
+        self.count += 1
         element_name = "%s%d" % (self.var, self.count)
         self.default += "%s%s%s\n" % (prefix, element_name, suffix)
         return element_name

--- a/dharma/grammars/svg.dg
+++ b/dharma/grammars/svg.dg
@@ -2235,10 +2235,13 @@ rendering_intent_value :=
 	absolute-colorimetric
 
 color_profile_element_attributes :=
+	name="@color_profile_name@"
+	+color_profile_element_attributes_without_name+
+
+color_profile_element_attributes_without_name :=
 	+core_attributes+
 	+xlink_attributes+
 	local="+local_value+"
-	name="@color_profile_name@"
 	rendering-intent="+rendering_intent_value+"
 
 color_profile_content_class :=
@@ -3180,7 +3183,7 @@ filter_primitive_ref :=
 	<svg><filter id="filter" filterUnits="userSpaceOnUse" x="0" y="0" width="1200" height="400"><feGaussianBlur stdDeviation="8" result="@filter_primitive_ref@"/></filter></svg>
 
 color_profile_name :=
-	<svg><color-pofile name="@color_profile_name@" %repeat%(+color_profile_element_attributes+, " ")></color-profile></svg>
+	<svg><color-profile name="@color_profile_name@" %repeat%(+color_profile_element_attributes_without_name+, " ")></color-profile></svg>
 
 a_target :=
 	<iframe id="@a_target@" width="1" height="1"></iframe>


### PR DESCRIPTION
This allows us to undo the change in 834203fc1bb7f99de5f88dd781e62f0089074ebd which causes incorrect output (fixes #23)